### PR TITLE
Move errors to Errors module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.4.0
+
+- Moved errors to `Aegis::Errors` module
+
 ## 0.3.6
 
 - Moved `NullSerializer` to `Types` module

--- a/lib/aegis/client.rb
+++ b/lib/aegis/client.rb
@@ -33,7 +33,7 @@ module Aegis
 
       query_status = wait_for_query_to_finish(query_execution_id)
 
-      raise Aegis::QueryExecutionError, query_status.message unless query_status.finished?
+      raise Aegis::Errors::QueryExecutionError, query_status.message unless query_status.finished?
 
       query_status
     end

--- a/lib/aegis/errors.rb
+++ b/lib/aegis/errors.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 
 module Aegis
-  class Error < StandardError; end
+  module Errors
+    class Error < StandardError; end
 
-  class UnsupportedTableFormat < Error; end
-  class QueryExecutionError < Error; end
-  class PartitionError < Error; end
-  class TypeError < Error; end
+    class UnsupportedTableFormat < Error; end
+    class QueryExecutionError < Error; end
+    class PartitionError < Error; end
+    class TypeError < Error; end
+  end
 end

--- a/lib/aegis/partitions_generator.rb
+++ b/lib/aegis/partitions_generator.rb
@@ -20,7 +20,7 @@ module Aegis
     attr_reader :cartesian_product_generator
 
     def validate_partition_values(values_by_partition)
-      raise PartitionError, 'Partition value(s) missing' if partition_values_missing?(values_by_partition)
+      raise Errors::PartitionError, 'Partition value(s) missing' if partition_values_missing?(values_by_partition)
     end
 
     def partition_values_missing?(values_by_partition)

--- a/lib/aegis/table_data_wiper.rb
+++ b/lib/aegis/table_data_wiper.rb
@@ -37,7 +37,7 @@ module Aegis
     def validate_partition_values(removed_partition_values, partitions)
       return unless removed_partition_values.empty? || removed_partition_values.values.any?(&:empty?)
 
-      raise Aegis::PartitionError, "Incorrect partitions given: #{partitions}"
+      raise Aegis::Errors::PartitionError, "Incorrect partitions given: #{partitions}"
     end
 
     def remove_partition_files(bucket, location, partitions_with_values)

--- a/lib/aegis/table_ddl_generator.rb
+++ b/lib/aegis/table_ddl_generator.rb
@@ -42,7 +42,7 @@ module Aegis
       when :orc
         'STORED AS ORC'
       else
-        raise UnsupportedTableFormat, format.to_s
+        raise Errors::UnsupportedTableFormat, format.to_s
       end
     end
   end

--- a/lib/aegis/version.rb
+++ b/lib/aegis/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Aegis
-  VERSION = '0.3.6'
+  VERSION = '0.4.0'
 end

--- a/spec/unit/aegis/client_spec.rb
+++ b/spec/unit/aegis/client_spec.rb
@@ -199,7 +199,7 @@ RSpec.describe Aegis::Client do
           expect(aws_athena_client).to receive(:get_query_execution).with({query_execution_id: query_execution_id}).
             and_return(get_query_execution_response[state]).once
 
-          expect { subject }.to raise_error(Aegis::QueryExecutionError)
+          expect { subject }.to raise_error(Aegis::Errors::QueryExecutionError)
         end
       end
 

--- a/spec/unit/aegis/partitions_generator_spec.rb
+++ b/spec/unit/aegis/partitions_generator_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe Aegis::PartitionsGenerator do
     let(:partitions) { {} }
 
     it 'raises an error' do
-      expect { subject }.to raise_error(Aegis::PartitionError)
+      expect { subject }.to raise_error(Aegis::Errors::PartitionError)
     end
   end
 
@@ -64,7 +64,7 @@ RSpec.describe Aegis::PartitionsGenerator do
     let(:partitions) { {country: []} }
 
     it 'raises an error' do
-      expect { subject }.to raise_error(Aegis::PartitionError)
+      expect { subject }.to raise_error(Aegis::Errors::PartitionError)
     end
   end
 
@@ -72,7 +72,7 @@ RSpec.describe Aegis::PartitionsGenerator do
     let(:partitions) { nil }
 
     it 'raises an error' do
-      expect { subject }.to raise_error(Aegis::PartitionError)
+      expect { subject }.to raise_error(Aegis::Errors::PartitionError)
     end
   end
 

--- a/spec/unit/aegis/table_data_wiper_spec.rb
+++ b/spec/unit/aegis/table_data_wiper_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe Aegis::TableDataWiper do
       let(:partitions) { {type: [1, 2]} }
 
       it 'raises an error' do
-        expect { subject }.to raise_error(Aegis::PartitionError)
+        expect { subject }.to raise_error(Aegis::Errors::PartitionError)
       end
     end
   end

--- a/spec/unit/aegis/table_ddl_generator_spec.rb
+++ b/spec/unit/aegis/table_ddl_generator_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe Aegis::TableDDLGenerator do
         let(:format) { :unknown_format }
 
         it 'raises an error' do
-          expect { subject }.to raise_error(Aegis::UnsupportedTableFormat)
+          expect { subject }.to raise_error(Aegis::Errors::UnsupportedTableFormat)
         end
       end
     end


### PR DESCRIPTION
I want to move errors to `Errors` module before we release 1.0.0

## Checklist

- [x] Bumped version tag in `lib/aegis/version.rb`
- [x] Added changes summary to [CHANGELOG](CHANGELOG.md)
