### PR TITLE
Fix aws-sdk-s3 not being a runtime dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 1.0.1
+
+- Fixed `aws-sdk-s3` not being a runtime dependency
+
 ## 1.0.0
 
 - Added `fetch_result` method to `Aegis::QueryStatus`

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,6 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in aegis.gemspec
 gemspec
 
-gem 'aws-sdk-s3', '~> 1.0'
 gem 'bundler'
 gem 'rake', '~> 10.0'
 gem 'rspec', '~> 3.0'

--- a/aegis.gemspec
+++ b/aegis.gemspec
@@ -31,4 +31,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'aws-sdk-athena', '~> 1.0'
+  spec.add_dependency 'aws-sdk-s3', '~> 1.0'
 end

--- a/lib/aegis/version.rb
+++ b/lib/aegis/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Aegis
-  VERSION = '1.0.0'
+  VERSION = '1.0.1'
 end


### PR DESCRIPTION
## Checklist

- [ ] Bumped version tag in `lib/aegis/version.rb`
- [ ] Added changes summary to [CHANGELOG](CHANGELOG.md)
