### PR TITLE
Fix/Handle configuration errors during tests

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## 1.0
 
+### 1.2.1
+
+- Fix testing mode error when AWS credentials missing
+
 ### 1.2.0
 
 - Add logger

--- a/lib/egis/testing.rb
+++ b/lib/egis/testing.rb
@@ -43,6 +43,6 @@ module Egis # rubocop:disable Style/Documentation
     yield
   ensure
     @mode = previous_mode
-    test_mode.cleanup
+    test_mode.cleanup if test_mode
   end
 end

--- a/lib/egis/version.rb
+++ b/lib/egis/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Egis
-  VERSION = '1.2.0'
+  VERSION = '1.2.1'
 end

--- a/spec/unit/egis/testing_spec.rb
+++ b/spec/unit/egis/testing_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Egis do
+  describe '.testing' do
+
+    context 'when AWS credentials set' do
+      before do
+        allow(Egis.configuration).to receive(:aws_access_key_id).and_return('access_key')
+        allow(Egis.configuration).to receive(:aws_secret_access_key).and_return('secret')
+      end
+
+      it 'uses testing mode for time of testing' do
+        Egis.testing do
+          expect(Egis.mode).to be_instance_of(Egis::Testing::TestingMode)
+        end
+      end
+
+      it 'restores standard mode after testing' do
+        Egis.testing {}
+        expect(Egis.mode).to be_instance_of(Egis::StandardMode)
+      end
+    end
+
+    context 'when error when initializing' do
+      let(:error) { 'missing credentials' }
+
+      before do
+        allow(Egis::Testing::TestingMode).to receive(:new).and_raise(error)
+      end
+
+      it 'raises missing aws credentials error' do
+        expect do
+          Egis.testing {}
+        end.to raise_error(error)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Gracefully handle situation when test_mode cannot be created due to an error

When AWS credential missing error message during tests were a bit cryptic.
## Before 
```
     Failure/Error:
       Egis.testing do
         example.run
       end

     NoMethodError:
       undefined method `cleanup' for nil:NilClass
```

## After
```
     Failure/Error:
       Egis.testing do
         example.run
       end

     Aws::Sigv4::Errors::MissingCredentialsError:
       missing credentials, provide credentials with one of the following options:
         - :access_key_id and :secret_access_key
         - :credentials
         - :credentials_provider
```

## Checklist

- [x] Bumped version tag in `lib/egis/version.rb`
- [x] Added changes summary to [CHANGELOG](/docs/CHANGELOG.md)
