### PR TITLE
Add serde support

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## 1.0
 
+### 1.3.0
+
+- Add ability to create Athena tables with SerDe
+
 ### 1.2.1
 
 - Fix testing mode error when AWS credentials missing

--- a/lib/egis/database.rb
+++ b/lib/egis/database.rb
@@ -28,7 +28,8 @@ module Egis
     # @param [String] table_name
     # @param [Egis::TableSchema] table_schema
     # @param [String] table_location S3 URL with table location (e.g. `s3://s3_bucket/table/location/`)
-    # @param [:tsv, :csv, :orc, {serde: 'SerdeClass', serde_properties: {property: value}}] format Table format (defaults to :tsv)
+    # @param [:tsv, :csv, :orc, {serde: 'SerdeClass', serde_properties: {property: value}}] format Table format
+    # (defaults to :tsv)
     # @return [Egis::Table]
 
     def table(table_name, table_schema, table_location, **options)

--- a/lib/egis/database.rb
+++ b/lib/egis/database.rb
@@ -28,7 +28,7 @@ module Egis
     # @param [String] table_name
     # @param [Egis::TableSchema] table_schema
     # @param [String] table_location S3 URL with table location (e.g. `s3://s3_bucket/table/location/`)
-    # @param [:tsv, :csv, :orc] format Table format (defaults to :tsv)
+    # @param [:tsv, :csv, :orc, {serde: 'SerdeClass', serde_properties: {property: value}}] format Table format (defaults to :tsv)
     # @return [Egis::Table]
 
     def table(table_name, table_schema, table_location, **options)

--- a/lib/egis/testing.rb
+++ b/lib/egis/testing.rb
@@ -43,6 +43,6 @@ module Egis # rubocop:disable Style/Documentation
     yield
   ensure
     @mode = previous_mode
-    test_mode.cleanup if test_mode
+    test_mode&.cleanup
   end
 end

--- a/lib/egis/version.rb
+++ b/lib/egis/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Egis
-  VERSION = '1.2.1'
+  VERSION = '1.3.0'
 end

--- a/spec/unit/egis/table_ddl_generator_spec.rb
+++ b/spec/unit/egis/table_ddl_generator_spec.rb
@@ -137,6 +137,59 @@ RSpec.describe Egis::TableDDLGenerator do
         it { is_expected.to eq(expected_query) }
       end
 
+      context 'when given table serde' do
+        let(:format) { {serde: 'org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe'} }
+
+        let(:expected_query) do
+          strip_whitespaces <<~SQL
+            CREATE EXTERNAL TABLE #{table_name} (
+              `id` int,
+              `message` string,
+              `time` timestamp
+            )
+            PARTITIONED BY (
+              `dth` int,
+              `type` string
+            )
+            ROW FORMAT SERDE 'org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe'
+            LOCATION '#{location}';
+          SQL
+        end
+
+        it { is_expected.to eq(expected_query) }
+      end
+
+      context 'when given table serde with serde properties' do
+        let(:format) do
+          {
+            serde: 'org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe',
+            serde_properties: {'serialization.format' => ',', 'field.delim' => ','}
+          }
+        end
+
+        let(:expected_query) do
+          strip_whitespaces <<~SQL
+            CREATE EXTERNAL TABLE #{table_name} (
+              `id` int,
+              `message` string,
+              `time` timestamp
+            )
+            PARTITIONED BY (
+              `dth` int,
+              `type` string
+            )
+            ROW FORMAT SERDE 'org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe'
+            WITH SERDEPROPERTIES (
+              'serialization.format' = ',',
+              'field.delim' = ','
+            )
+            LOCATION '#{location}';
+          SQL
+        end
+
+        it { is_expected.to eq(expected_query) }
+      end
+
       context 'when given an unsupported format' do
         let(:format) { :unknown_format }
 

--- a/spec/unit/egis/testing_spec.rb
+++ b/spec/unit/egis/testing_spec.rb
@@ -4,7 +4,6 @@ require 'spec_helper'
 
 RSpec.describe Egis do
   describe '.testing' do
-
     context 'when AWS credentials set' do
       before do
         allow(Egis.configuration).to receive(:aws_access_key_id).and_return('access_key')


### PR DESCRIPTION
Add ability to create tables with a custom serde configuration: https://docs.aws.amazon.com/athena/latest/ug/serde-about.html

The syntax will be as follows:
```
database.table(table_name, schema, location, format: {
  serde: 'org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe',
  serde_properties: {'serialization.format' => ',', 'field.delim' => ','}
} 
```

## Checklist

- [x] Bumped version tag in `lib/egis/version.rb`
- [x] Added changes summary to [CHANGELOG](/docs/CHANGELOG.md)
