### PR TITLE
Configure egis instance

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### 1.5.0
 
-- Optionally configure Egis::Client in runtime
+- Ability to configure Egis per client
 
 ### 1.4.0
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## 1.0
 
+### 1.5.0
+
+- Optionally configure Egis::Client in runtime
+
 ### 1.4.0
 
 - Add ability to insert data with hash values rather than arrays

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -24,6 +24,13 @@ Egis.configure do |config|
 end
 ```
 
+Alternatively, egis can be configured in runtime:
+```ruby
+Egis::Client.new do |config|
+  config.aws_region = 'AWS region'
+end
+```
+
 `Egis` client is a class that provides you with the interface for schema manipulation and running queries
 
 ```ruby

--- a/lib/egis.rb
+++ b/lib/egis.rb
@@ -50,8 +50,8 @@ require 'egis/s3_location_parser'
 #
 module Egis
   class << self
-    def configure
-      yield(configuration)
+    def configure(&block)
+      configuration.configure(&block)
     end
 
     # @!visibility private

--- a/lib/egis/aws_client_provider.rb
+++ b/lib/egis/aws_client_provider.rb
@@ -6,23 +6,17 @@ require 'aws-sdk-athena'
 module Egis
   # @!visibility private
   class AwsClientProvider
-    def initialize(configuration)
-      @configuration = configuration
+    def s3_client(configuration)
+      Aws::S3::Client.new(client_config(configuration))
     end
 
-    def s3_client
-      Aws::S3::Client.new(client_config)
-    end
-
-    def athena_client
-      Aws::Athena::Client.new(client_config)
+    def athena_client(configuration)
+      Aws::Athena::Client.new(client_config(configuration))
     end
 
     private
 
-    attr_reader :configuration
-
-    def client_config
+    def client_config(configuration)
       {
         region: configuration.aws_region,
         access_key_id: configuration.aws_access_key_id,

--- a/lib/egis/aws_client_provider.rb
+++ b/lib/egis/aws_client_provider.rb
@@ -23,12 +23,12 @@ module Egis
     attr_reader :configuration
 
     def client_config
-      config = {}
-      config[:region] = configuration.aws_region if configuration.aws_region
-      config[:access_key_id] = configuration.aws_access_key_id if configuration.aws_access_key_id
-      config[:secret_access_key] = configuration.aws_secret_access_key if configuration.aws_secret_access_key
-      config[:profile] = configuration.aws_profile if configuration.aws_profile
-      config
+      {
+        region: configuration.aws_region,
+        access_key_id: configuration.aws_access_key_id,
+        secret_access_key: configuration.aws_secret_access_key,
+        profile: configuration.aws_profile
+      }.compact
     end
   end
 end

--- a/lib/egis/aws_client_provider.rb
+++ b/lib/egis/aws_client_provider.rb
@@ -6,6 +6,10 @@ require 'aws-sdk-athena'
 module Egis
   # @!visibility private
   class AwsClientProvider
+    def initialize(configuration)
+      @configuration = configuration
+    end
+
     def s3_client
       Aws::S3::Client.new(client_config)
     end
@@ -16,9 +20,9 @@ module Egis
 
     private
 
-    def client_config
-      configuration = Egis.configuration
+    attr_reader :configuration
 
+    def client_config
       config = {}
       config[:region] = configuration.aws_region if configuration.aws_region
       config[:access_key_id] = configuration.aws_access_key_id if configuration.aws_access_key_id

--- a/lib/egis/client.rb
+++ b/lib/egis/client.rb
@@ -4,6 +4,9 @@ module Egis
   ##
   # The most fundamental {Egis} class. Provides an interface for executing Athena queries.
   #
+  # @yieldparam config [Egis::Configuration] Egis configuration block, if missing Egis will use global configuration
+  #   provided by {Egis.configure}
+  #
   # See configuration instructions {Egis.configure}.
   #
   # @see Egis.configure

--- a/lib/egis/client.rb
+++ b/lib/egis/client.rb
@@ -44,7 +44,7 @@ module Egis
                    s3_location_parser: Egis::S3LocationParser.new,
                    &block
     )
-      @configuration = block_given? ? Egis.configuration.configure(&block) : Egis.configuration
+      @configuration = block_given? ? Egis.configuration.dup.configure(&block) : Egis.configuration
       aws_client_provider ||= Egis::AwsClientProvider.new(configuration)
       @aws_athena_client = aws_client_provider.athena_client
       @s3_location_parser = s3_location_parser

--- a/lib/egis/client.rb
+++ b/lib/egis/client.rb
@@ -38,7 +38,7 @@ module Egis
 
     private_constant :QUERY_STATUS_MAPPING
 
-    attr_reader :output_downloader, :s3_cleaner
+    attr_reader :aws_s3_client
 
     def initialize(aws_client_provider: Egis::AwsClientProvider.new,
                    s3_location_parser: Egis::S3LocationParser.new,
@@ -47,8 +47,6 @@ module Egis
       @aws_athena_client = aws_client_provider.athena_client(configuration)
       @aws_s3_client = aws_client_provider.s3_client(configuration)
       @s3_location_parser = s3_location_parser
-      @output_downloader = Egis::OutputDownloader.new(aws_s3_client)
-      @s3_cleaner = Egis::S3Cleaner.new(aws_s3_client)
     end
 
     ##
@@ -108,13 +106,13 @@ module Egis
         QUERY_STATUS_MAPPING.fetch(query_status),
         query_execution.status.state_change_reason,
         parse_output_location(query_execution),
-        output_downloader: output_downloader
+        client: self
       )
     end
 
     private
 
-    attr_reader :configuration, :aws_athena_client, :s3_location_parser, :aws_s3_client
+    attr_reader :configuration, :aws_athena_client, :s3_location_parser
 
     def query_execution_params(query, work_group, database, output_location)
       work_group_params = work_group || configuration.work_group

--- a/lib/egis/configuration.rb
+++ b/lib/egis/configuration.rb
@@ -8,6 +8,12 @@ module Egis
 
     def initialize
       @logger = Logger.new(STDOUT, level: :info)
+      @query_status_backoff = ->(attempt) { 1.5**attempt - 1 }
+    end
+
+    def configure
+      yield(self)
+      self
     end
   end
 end

--- a/lib/egis/database.rb
+++ b/lib/egis/database.rb
@@ -14,10 +14,9 @@ module Egis
   #   @return [String] Athena database name
   #
   class Database
-    def initialize(name, client: Egis::Client.new, output_downloader: Egis::OutputDownloader.new(client: client))
+    def initialize(name, client: Egis::Client.new)
       @client = client
       @name = name
-      @output_downloader = output_downloader
     end
 
     attr_reader :name, :client
@@ -33,7 +32,7 @@ module Egis
     # @return [Egis::Table]
 
     def table(table_name, table_schema, table_location, **options)
-      Table.new(self, table_name, table_schema, table_location, options: options, output_downloader: output_downloader)
+      Table.new(self, table_name, table_schema, table_location, options: options)
     end
 
     ##
@@ -103,13 +102,11 @@ module Egis
 
     def exists?
       query_status = client.execute_query("SHOW DATABASES LIKE '#{name}';", async: false, system_execution: true)
-      parsed_result = output_downloader.download(query_status.output_location)
+      parsed_result = client.output_downloader.download(query_status.output_location)
       parsed_result.flatten.include?(name)
     end
 
     private
-
-    attr_reader :output_downloader
 
     def log_database_creation
       Egis.logger.info { "Creating database #{name}" }

--- a/lib/egis/database.rb
+++ b/lib/egis/database.rb
@@ -14,13 +14,13 @@ module Egis
   #   @return [String] Athena database name
   #
   class Database
-    def initialize(name, client: Egis::Client.new, output_downloader: Egis::OutputDownloader.new)
+    def initialize(name, client: Egis::Client.new, output_downloader: Egis::OutputDownloader.new(client: client))
       @client = client
       @name = name
       @output_downloader = output_downloader
     end
 
-    attr_reader :name
+    attr_reader :name, :client
 
     ##
     # Creates {Egis::Table} object. Executing it doesn't create Athena table yet.
@@ -33,7 +33,7 @@ module Egis
     # @return [Egis::Table]
 
     def table(table_name, table_schema, table_location, **options)
-      Table.new(self, table_name, table_schema, table_location, options: options)
+      Table.new(self, table_name, table_schema, table_location, options: options, output_downloader: output_downloader)
     end
 
     ##
@@ -109,7 +109,7 @@ module Egis
 
     private
 
-    attr_reader :client, :output_downloader
+    attr_reader :output_downloader
 
     def log_database_creation
       Egis.logger.info { "Creating database #{name}" }

--- a/lib/egis/output_downloader.rb
+++ b/lib/egis/output_downloader.rb
@@ -5,8 +5,8 @@ require 'csv'
 module Egis
   # @!visibility private
   class OutputDownloader
-    def initialize(aws_client_provider: Egis::AwsClientProvider.new)
-      @s3_client = aws_client_provider.s3_client
+    def initialize(client:)
+      @s3_client = client.aws_s3_client
     end
 
     def download(output_location)

--- a/lib/egis/output_downloader.rb
+++ b/lib/egis/output_downloader.rb
@@ -5,8 +5,8 @@ require 'csv'
 module Egis
   # @!visibility private
   class OutputDownloader
-    def initialize(client:)
-      @s3_client = client.aws_s3_client
+    def initialize(aws_s3_client:)
+      @s3_client = aws_s3_client
     end
 
     def download(output_location)

--- a/lib/egis/output_downloader.rb
+++ b/lib/egis/output_downloader.rb
@@ -5,7 +5,7 @@ require 'csv'
 module Egis
   # @!visibility private
   class OutputDownloader
-    def initialize(aws_s3_client:)
+    def initialize(aws_s3_client)
       @s3_client = aws_s3_client
     end
 

--- a/lib/egis/query_status.rb
+++ b/lib/egis/query_status.rb
@@ -23,7 +23,8 @@ module Egis
     attr_reader :id, :status, :message, :output_location
 
     def initialize(id, status, message, output_location,
-                   output_downloader: Egis::OutputDownloader.new,
+                   client: Egis::Client.new,
+                   output_downloader: Egis::OutputDownloader.new(client.aws_s3_client),
                    output_parser: Egis::OutputParser.new)
       raise ArgumentError, "Unsupported status #{status}" unless STATUSES.include?(status)
 

--- a/lib/egis/query_status.rb
+++ b/lib/egis/query_status.rb
@@ -52,6 +52,10 @@ module Egis
       status == RUNNING
     end
 
+    def cancelled?
+      status == CANCELLED
+    end
+
     def in_progress?
       [RUNNING, QUEUED].include?(status)
     end

--- a/lib/egis/s3_cleaner.rb
+++ b/lib/egis/s3_cleaner.rb
@@ -3,8 +3,8 @@
 module Egis
   # @!visibility private
   class S3Cleaner
-    def initialize(aws_client_provider: Egis::AwsClientProvider.new)
-      @s3_client = aws_client_provider.s3_client
+    def initialize(client:)
+      @s3_client = client.aws_s3_client
     end
 
     def delete(bucket, prefix)

--- a/lib/egis/s3_cleaner.rb
+++ b/lib/egis/s3_cleaner.rb
@@ -3,7 +3,7 @@
 module Egis
   # @!visibility private
   class S3Cleaner
-    def initialize(aws_s3_client:)
+    def initialize(aws_s3_client)
       @s3_client = aws_s3_client
     end
 

--- a/lib/egis/s3_cleaner.rb
+++ b/lib/egis/s3_cleaner.rb
@@ -3,8 +3,8 @@
 module Egis
   # @!visibility private
   class S3Cleaner
-    def initialize(client:)
-      @s3_client = client.aws_s3_client
+    def initialize(aws_s3_client:)
+      @s3_client = aws_s3_client
     end
 
     def delete(bucket, prefix)

--- a/lib/egis/table.rb
+++ b/lib/egis/table.rb
@@ -19,9 +19,10 @@ module Egis
     def initialize(database, name, schema, location, options: {},
                    partitions_generator: Egis::PartitionsGenerator.new,
                    table_ddl_generator: Egis::TableDDLGenerator.new,
-                   output_downloader: Egis::OutputDownloader.new,
+                   output_downloader: Egis::OutputDownloader.new(client: database.client),
                    output_parser: Egis::OutputParser.new,
-                   table_data_wiper: Egis::TableDataWiper.new)
+                   s3_cleaner: Egis::S3Cleaner.new(client: database.client),
+                   table_data_wiper: Egis::TableDataWiper.new(s3_cleaner: s3_cleaner))
       @database = database
       @name = name
       @schema = schema

--- a/lib/egis/testing/testing_mode.rb
+++ b/lib/egis/testing/testing_mode.rb
@@ -6,11 +6,13 @@ module Egis
     class TestingMode
       def initialize(test_id, s3_bucket,
                      client: Egis::Client.new,
+                     output_downloader: Egis::OutputDownloader.new(client.aws_s3_client),
                      s3_location_parser: Egis::S3LocationParser.new)
         @test_id = test_id
         @s3_bucket = s3_bucket
         @dirty = false
         @client = client
+        @output_downloader = output_downloader
         @s3_location_parser = s3_location_parser
       end
 
@@ -40,11 +42,11 @@ module Egis
 
       private
 
-      attr_reader :test_id, :s3_bucket, :client, :s3_location_parser
+      attr_reader :test_id, :s3_bucket, :client, :output_downloader, :s3_location_parser
 
       def remove_test_databases
         result = client.execute_query("SHOW DATABASES LIKE '#{test_id}.*';", async: false)
-        query_result = client.output_downloader.download(result.output_location)
+        query_result = output_downloader.download(result.output_location)
         query_result.flatten.each { |database| client.database(database).drop }
       end
 

--- a/lib/egis/testing/testing_mode.rb
+++ b/lib/egis/testing/testing_mode.rb
@@ -6,13 +6,11 @@ module Egis
     class TestingMode
       def initialize(test_id, s3_bucket,
                      client: Egis::Client.new,
-                     output_downloader: Egis::OutputDownloader.new(client: client),
                      s3_location_parser: Egis::S3LocationParser.new)
         @test_id = test_id
         @s3_bucket = s3_bucket
         @dirty = false
         @client = client
-        @output_downloader = output_downloader
         @s3_location_parser = s3_location_parser
       end
 
@@ -42,11 +40,11 @@ module Egis
 
       private
 
-      attr_reader :test_id, :s3_bucket, :client, :output_downloader, :s3_location_parser
+      attr_reader :test_id, :s3_bucket, :client, :s3_location_parser
 
       def remove_test_databases
         result = client.execute_query("SHOW DATABASES LIKE '#{test_id}.*';", async: false)
-        query_result = output_downloader.download(result.output_location)
+        query_result = client.output_downloader.download(result.output_location)
         query_result.flatten.each { |database| client.database(database).drop }
       end
 

--- a/lib/egis/testing/testing_mode.rb
+++ b/lib/egis/testing/testing_mode.rb
@@ -6,7 +6,7 @@ module Egis
     class TestingMode
       def initialize(test_id, s3_bucket,
                      client: Egis::Client.new,
-                     output_downloader: Egis::OutputDownloader.new,
+                     output_downloader: Egis::OutputDownloader.new(client: client),
                      s3_location_parser: Egis::S3LocationParser.new)
         @test_id = test_id
         @s3_bucket = s3_bucket

--- a/lib/egis/version.rb
+++ b/lib/egis/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Egis
-  VERSION = '1.4.0'
+  VERSION = '1.5.0'
 end

--- a/spec/integration/egis_spec.rb
+++ b/spec/integration/egis_spec.rb
@@ -3,11 +3,9 @@
 require 'spec_helper'
 
 RSpec.describe 'Integration with AWS Athena' do
-  Egis.configure do |config|
+  client = Egis::Client.new do |config|
     config.work_group = 'egis-integration-testing'
   end
-
-  client = Egis::Client.new
   test_id = "#{Time.now.to_i}_#{Random.rand(100)}"
   database = client.database("egis_integration_test_#{test_id}")
   testing_bucket = 'egis-integration-testing'

--- a/spec/unit/egis/client_spec.rb
+++ b/spec/unit/egis/client_spec.rb
@@ -16,6 +16,34 @@ RSpec.describe Egis::Client do
   let(:aws_s3_client) { Aws::S3::Client.new(stub_responses: true) }
   let(:work_group) { 'test_work_group' }
 
+  describe '#initialize' do
+    subject(:client) { described_class.new }
+
+    let(:default_region) { 'us-east-1' }
+    let(:custom_region) { 'us-west-1' }
+
+    before do
+      @old_region = Egis.configuration.aws_region
+      Egis.configure { |config| config.aws_region = default_region }
+    end
+    after { Egis.configuration.aws_region = @old_region }
+
+    context 'when using global configuration' do
+      it { expect(client.send(:aws_athena_client).config.region).to eq(default_region) }
+    end
+
+    context 'when using local configuration' do
+      subject(:client) do
+        described_class.new { |config| config.aws_region = custom_region }
+      end
+
+      specify do
+        expect(client.send(:aws_athena_client).config.region).to eq(custom_region)
+        expect(Egis.configuration.aws_region).to eq(default_region)
+      end
+    end
+  end
+
   describe '#query_status' do
     subject { client.query_status(query_execution_id) }
 

--- a/spec/unit/egis/client_spec.rb
+++ b/spec/unit/egis/client_spec.rb
@@ -3,20 +3,18 @@
 require 'spec_helper'
 
 RSpec.describe Egis::Client do
-  let(:client) { described_class.new(aws_client_provider: aws_client_provider) }
+  let(:client) do
+    described_class.new(aws_client_provider: aws_client_provider) do |config|
+      config.work_group = work_group
+      config.query_status_backoff = ->(_i) { 0.01 }
+    end
+  end
   let(:aws_client_provider) do
     instance_double(Egis::AwsClientProvider, s3_client: aws_s3_client, athena_client: aws_athena_client)
   end
   let(:aws_athena_client) { Aws::Athena::Client.new(stub_responses: true) }
   let(:aws_s3_client) { Aws::S3::Client.new(stub_responses: true) }
   let(:work_group) { 'test_work_group' }
-
-  before do
-    ::Egis.configure do |config|
-      config.work_group = work_group
-      config.query_status_backoff = ->(_i) { 0.01 }
-    end
-  end
 
   describe '#query_status' do
     subject { client.query_status(query_execution_id) }

--- a/spec/unit/egis/client_spec.rb
+++ b/spec/unit/egis/client_spec.rb
@@ -4,8 +4,11 @@ require 'spec_helper'
 
 RSpec.describe Egis::Client do
   let(:client) { described_class.new(aws_client_provider: aws_client_provider) }
-  let(:aws_client_provider) { instance_double(Egis::AwsClientProvider, athena_client: aws_athena_client) }
+  let(:aws_client_provider) do
+    instance_double(Egis::AwsClientProvider, s3_client: aws_s3_client, athena_client: aws_athena_client)
+  end
   let(:aws_athena_client) { Aws::Athena::Client.new(stub_responses: true) }
+  let(:aws_s3_client) { Aws::S3::Client.new(stub_responses: true) }
   let(:work_group) { 'test_work_group' }
 
   before do

--- a/spec/unit/egis/database_spec.rb
+++ b/spec/unit/egis/database_spec.rb
@@ -3,10 +3,10 @@
 require 'spec_helper'
 
 RSpec.describe Egis::Database do
-  let(:database) { described_class.new(database_name, client: client, output_downloader: output_downloader) }
-  let(:client) { instance_double(Egis::Client, aws_s3_client: aws_s3_client) }
-  let(:aws_s3_client) { Aws::S3::Client.new(stub_responses: true) }
+  let(:database) { described_class.new(database_name, client: client) }
+  let(:client) { instance_double(Egis::Client, output_downloader: output_downloader, s3_cleaner: s3_cleaner) }
   let(:output_downloader) { instance_double(Egis::OutputDownloader) }
+  let(:s3_cleaner) { instance_double(Egis::S3Cleaner) }
 
   let(:database_name) { 'name' }
   let(:table_name) { 'table' }

--- a/spec/unit/egis/database_spec.rb
+++ b/spec/unit/egis/database_spec.rb
@@ -4,7 +4,8 @@ require 'spec_helper'
 
 RSpec.describe Egis::Database do
   let(:database) { described_class.new(database_name, client: client, output_downloader: output_downloader) }
-  let(:client) { instance_double(Egis::Client) }
+  let(:client) { instance_double(Egis::Client, aws_s3_client: aws_s3_client) }
+  let(:aws_s3_client) { Aws::S3::Client.new(stub_responses: true) }
   let(:output_downloader) { instance_double(Egis::OutputDownloader) }
 
   let(:database_name) { 'name' }
@@ -101,7 +102,9 @@ RSpec.describe Egis::Database do
     subject { database.exists? }
 
     let(:location) { Egis::QueryOutputLocation.new('url', 'bucket', 'key') }
-    let(:query_status) { Egis::QueryStatus.new('123', Egis::QueryStatus::FINISHED, 'ok', location) }
+    let(:query_status) do
+      Egis::QueryStatus.new('123', Egis::QueryStatus::FINISHED, 'ok', location, output_downloader: output_downloader)
+    end
     let(:query) { "SHOW DATABASES LIKE '#{database_name}';" }
 
     context 'when db present' do

--- a/spec/unit/egis/database_spec.rb
+++ b/spec/unit/egis/database_spec.rb
@@ -3,8 +3,9 @@
 require 'spec_helper'
 
 RSpec.describe Egis::Database do
-  let(:database) { described_class.new(database_name, client: client) }
-  let(:client) { instance_double(Egis::Client, output_downloader: output_downloader, s3_cleaner: s3_cleaner) }
+  let(:database) { described_class.new(database_name, client: client, output_downloader: output_downloader) }
+  let(:client) { instance_double(Egis::Client, aws_s3_client: aws_s3_client) }
+  let(:aws_s3_client) { Aws::S3::Client.new(stub_responses: true) }
   let(:output_downloader) { instance_double(Egis::OutputDownloader) }
   let(:s3_cleaner) { instance_double(Egis::S3Cleaner) }
 

--- a/spec/unit/egis/s3_cleaner_spec.rb
+++ b/spec/unit/egis/s3_cleaner_spec.rb
@@ -3,9 +3,9 @@
 require 'spec_helper'
 
 RSpec.describe Egis::S3Cleaner do
-  let(:cleaner) { described_class.new(aws_client_provider: aws_client_provider) }
+  let(:cleaner) { described_class.new(client: egis_client) }
   let(:s3_client) { Aws::S3::Client.new(stub_responses: true) }
-  let(:aws_client_provider) { instance_double(Egis::AwsClientProvider, s3_client: s3_client) }
+  let(:egis_client) { instance_double(Egis::Client, aws_s3_client: s3_client) }
 
   let(:s3_path_prefix) { 's3_path' }
   let(:bucket_name) { 'bucket_name' }

--- a/spec/unit/egis/s3_cleaner_spec.rb
+++ b/spec/unit/egis/s3_cleaner_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 RSpec.describe Egis::S3Cleaner do
-  let(:cleaner) { described_class.new(aws_s3_client: s3_client) }
+  let(:cleaner) { described_class.new(s3_client) }
   let(:s3_client) { Aws::S3::Client.new(stub_responses: true) }
 
   let(:s3_path_prefix) { 's3_path' }

--- a/spec/unit/egis/s3_cleaner_spec.rb
+++ b/spec/unit/egis/s3_cleaner_spec.rb
@@ -3,9 +3,8 @@
 require 'spec_helper'
 
 RSpec.describe Egis::S3Cleaner do
-  let(:cleaner) { described_class.new(client: egis_client) }
+  let(:cleaner) { described_class.new(aws_s3_client: s3_client) }
   let(:s3_client) { Aws::S3::Client.new(stub_responses: true) }
-  let(:egis_client) { instance_double(Egis::Client, aws_s3_client: s3_client) }
 
   let(:s3_path_prefix) { 's3_path' }
   let(:bucket_name) { 'bucket_name' }

--- a/spec/unit/egis/table_spec.rb
+++ b/spec/unit/egis/table_spec.rb
@@ -7,10 +7,12 @@ RSpec.describe Egis::Table do
     described_class.new(database, table_name, table_schema, table_location, partitions_generator: partitions_generator,
                                                                             table_ddl_generator: table_ddl_generator,
                                                                             output_downloader: output_downloader,
-                                                                            table_data_wiper: table_data_wiper)
+                                                                            table_data_wiper: table_data_wiper,
+                                                                            s3_cleaner: s3_cleaner)
   end
 
   let(:database) { instance_double(Egis::Database) }
+  let(:s3_cleaner) { instance_double(Egis::S3Cleaner) }
   let(:table_name) { 'table' }
   let(:table_schema) { instance_double(Egis::TableSchema) }
   let(:table_location) { 's3://bucket/table_key' }
@@ -212,7 +214,9 @@ RSpec.describe Egis::Table do
 
     let(:expected_query) { 'SELECT * FROM table;' }
 
-    let(:query_status) { Egis::QueryStatus.new('123', :finished, 'query message', output_location) }
+    let(:query_status) do
+      Egis::QueryStatus.new('123', :finished, 'query message', output_location, output_downloader: output_downloader)
+    end
     let(:output_location) { Egis::QueryOutputLocation.new('s3://bucket/path', 'bucket', 'path') }
 
     it 'downloads and parses data correctly' do

--- a/spec/unit/egis/table_spec.rb
+++ b/spec/unit/egis/table_spec.rb
@@ -6,11 +6,11 @@ RSpec.describe Egis::Table do
   let(:table) do
     described_class.new(database, table_name, table_schema, table_location, partitions_generator: partitions_generator,
                                                                             table_ddl_generator: table_ddl_generator,
+                                                                            output_downloader: output_downloader,
                                                                             table_data_wiper: table_data_wiper)
   end
 
-  let(:database) { instance_double(Egis::Database, client: egis_client) }
-  let(:egis_client) { instance_double(Egis::Client, output_downloader: output_downloader) }
+  let(:database) { instance_double(Egis::Database) }
   let(:table_name) { 'table' }
   let(:table_schema) { instance_double(Egis::TableSchema) }
   let(:table_location) { 's3://bucket/table_key' }

--- a/spec/unit/egis/table_spec.rb
+++ b/spec/unit/egis/table_spec.rb
@@ -6,13 +6,11 @@ RSpec.describe Egis::Table do
   let(:table) do
     described_class.new(database, table_name, table_schema, table_location, partitions_generator: partitions_generator,
                                                                             table_ddl_generator: table_ddl_generator,
-                                                                            output_downloader: output_downloader,
-                                                                            table_data_wiper: table_data_wiper,
-                                                                            s3_cleaner: s3_cleaner)
+                                                                            table_data_wiper: table_data_wiper)
   end
 
-  let(:database) { instance_double(Egis::Database) }
-  let(:s3_cleaner) { instance_double(Egis::S3Cleaner) }
+  let(:database) { instance_double(Egis::Database, client: egis_client) }
+  let(:egis_client) { instance_double(Egis::Client, output_downloader: output_downloader) }
   let(:table_name) { 'table' }
   let(:table_schema) { instance_double(Egis::TableSchema) }
   let(:table_location) { 's3://bucket/table_key' }


### PR DESCRIPTION
Currently egis can be configured only globally per project which doesn't allow to use athena on two different regions. In this pull request I'd like to add ability to configure Egis in runtime so that client configuration is independent from global configuration.

## Checklist

- [x] Bumped version tag in `lib/egis/version.rb`
- [x] Added changes summary to [CHANGELOG](/docs/CHANGELOG.md)
